### PR TITLE
Adding battery lockout to avoid overloading ESL node(s)

### DIFF
--- a/internal/tc2-hat-comms/at-esl.go
+++ b/internal/tc2-hat-comms/at-esl.go
@@ -94,7 +94,7 @@ func (a ATESLMessenger) processBatteryEvent(b batteryEvent, l *ATESLLastBattery)
 		return nil
 	}
 
-	// AT command, sending a battery reading as hundreths of a volt
+	// AT command, sending a battery reading as hundredths of a volt
 	atCmd := fmt.Sprintf("AT+CAMBAT=%d", int32(b.Voltage*100))
 
 	_, err := sendATCommand(atCmd, a.baudRate)


### PR DESCRIPTION
Just running off the default 3hr setting for now until we decide what registery settings / node communication is appropriate.