### PR TITLE
fix: harden at-esl registry reads

### DIFF
--- a/internal/tc2-hat-comms/at-esl.go
+++ b/internal/tc2-hat-comms/at-esl.go
@@ -13,11 +13,20 @@ import (
 )
 
 var (
-	predictionLockoutNodeRegister     int   = 5
-	predictionLockoutMinutesDefault   int64 = 30 // default 30mins.
-	batteryLockoutHoursNodeRegister   int   = 12
-	batteryLockoutMinutesNodeRegister int   = 13
+	// Node register addresses (hex), matching cmdpro wXX / m00 dump lines.
+	// 0x05 = EVENT_LOCKOUT_MINS (prediction).
+	// 0x12/0x13 = HOURS/MINS_PER_INST_READING — battery is an instrument reading;
+	// these set how often we report those readings.
+	predictionLockoutNodeRegister     int   = 0x05
+	predictionLockoutMinutesDefault   int64 = 1 // default 1min.
+
+	batteryLockoutHoursNodeRegister   int   = 0x12
+	batteryLockoutMinutesNodeRegister int   = 0x13
 	batteryLockoutMinutesDefault      int64 = 180 // default 180mins (3 hours).
+
+	// Pause after AT wake before the real command so the node can leave the wake
+	// O^K and accept AT+XCMD / AT+CAM.
+	atPostWakeSettle = 300 * time.Millisecond
 )
 
 type ATESLMessenger struct {
@@ -107,8 +116,8 @@ func (a ATESLMessenger) processBatteryEvent(b batteryEvent, l *ATESLLastBattery)
 	l.Voltage = b.Voltage // Remember the voltage reading
 	l.When = time.Now()   // Remember when we detected it
 
-	// Now let's check the event lockout
-	l.Lockout = getBatteryEventLockout(a.BaudRate)
+	// Re-query lockout (hub may have changed w12/w13); keep last-good on failure.
+	l.Lockout = getBatteryEventLockout(a.BaudRate, l.Lockout)
 
 	return nil
 }
@@ -181,8 +190,8 @@ func (a ATESLMessenger) processTrackingEvent(t trackingEvent, l *ATESLLastPredic
 		//tn := getThumbnail(t.ClipId, t.TrackId)
 		//log.Infof("Thumbnail is: %d×%d", len(tn), len(tn[0]))
 
-		// Now let's check the event lockout
-		l.Lockout = getPredictionEventLockout(a.BaudRate)
+		// Re-query lockout (hub may have changed w05); keep last-good on failure.
+		l.Lockout = getPredictionEventLockout(a.BaudRate, l.Lockout)
 	}
 
 	return nil
@@ -202,7 +211,6 @@ func sendATWakeUp(baudRate int) error {
 		err := serialhelper.SerialSend(1, gpio.High, gpio.Low, 10*time.Second, payload, baudRate)
 		attempt = attempt + 1
 
-		// response, err := serialhelper.SerialSendReceive(1, gpio.High, gpio.Low, 10*time.Second, payload, baudRate)
 		if err != nil {
 			return fmt.Errorf("serial send error: %w", err)
 		}
@@ -231,11 +239,18 @@ func sendATCommand(command string, baudRate int) ([]byte, error) {
 		return response, fmt.Errorf("could not wake serial receiver: %w", err)
 	}
 
-	// O^K now send the AT command
+	// Give the node time to finish the wake O^K and be ready for the next AT command.
+	time.Sleep(atPostWakeSettle)
+
+	// O^K now send the AT command. Drain clears wake leftover; read until O^K/E^RROR
+	// so multi-line responses (e.g. m00 register dump) are kept intact.
 	payload := append([]byte(command), byte('\r'))
 	log.Infof("Sending AT command: %s", command)
 
-	response, err = serialhelper.SerialSendReceive(1, gpio.High, gpio.Low, 5*time.Second, payload, baudRate)
+	response, err = serialhelper.SerialSendReceiveUntil(
+		1, gpio.High, gpio.Low, 5*time.Second, payload, baudRate, 3*time.Second,
+		[]byte("O^K"), []byte("E^RROR"),
+	)
 	if err != nil {
 		return response, fmt.Errorf("serial send receive error: %w", err)
 	}
@@ -258,64 +273,91 @@ func sendATCommand(command string, baudRate int) ([]byte, error) {
 	return response, nil
 }
 
-func getRegisteryData(baudRate int, reg int) int64 {
-	regCmd := "m00"
-
-	// Currently limited to the first 'page' of registery data (m00)
-	cmd := append([]byte("AT+XCMD="+regCmd), calcCRC16([]byte(regCmd))...)
-	log.Infof("get reg %d, data via command %v", reg, cmd)
-
-	response, _ := sendATCommand(string(cmd), baudRate)
-
-	// Let's clean-up the output - trim any unwanted charaters
-	if idx := bytes.Index(response, []byte(regCmd+"\r\n\r\n")); idx != -1 {
-		response = response[idx:]
-	} else {
-		// fallback: not found, just log and continue
-		log.Warnf("Registry command marker [%v] not found; keeping full response", regCmd)
+// parseRegistryByte extracts one register byte from an mXX hex dump.
+// reg is the node register address (e.g. 0x05, 0x12). Value 0xff is treated as unset (0).
+func parseRegistryByte(response []byte, reg int) (int64, error) {
+	if len(response) == 0 {
+		return 0, fmt.Errorf("empty registry response")
 	}
 
-	col := reg % 10
-	row := 0
-	if reg > 10 {
-		row = reg / (reg - (reg % 10))
-	}
+	addr := reg & 0xff
+	rowBase := addr & 0xf0
+	col := addr & 0x0f
+	prefix := fmt.Sprintf("%02x:", rowBase)
 
-	// w05..
-	// response.. \xa5\xfc\r\nm00\r\n\r\n00: ff ff ff ff ff 02
-	// First, second, third or fourth row of node register block - 00:
-	seq := fmt.Sprintf("%02x:", row*16)
-	pos := 0
-
-	log.Debugf("Searching for %v in response", seq)
-	for i := 0; i <= len(response)-3; i++ {
-		if response[i] == seq[0] && response[i+1] == seq[1] && response[i+2] == seq[2] {
-			log.Debugf("Found %v - position: %d", seq, i)
-			pos = i + 3 + col*3 + 1 // aka it's the nth element + drop the leading space
-			break
+	scanner := bufio.NewScanner(bytes.NewReader(response))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
 		}
+		lower := strings.ToLower(line)
+		if !strings.HasPrefix(lower, prefix) {
+			continue
+		}
+		fields := strings.Fields(lower)
+		// fields[0] is "00:", remaining are hex bytes
+		if len(fields) < col+2 {
+			return 0, fmt.Errorf("registry line %q too short for column %d", line, col)
+		}
+		hexstr := fields[col+1]
+		if len(hexstr) != 2 {
+			return 0, fmt.Errorf("invalid hex byte %q on line %q", hexstr, line)
+		}
+		regValue, err := strconv.ParseInt(hexstr, 16, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parseInt %q: %w", hexstr, err)
+		}
+		if regValue == 255 {
+			log.Debugf("Reg 0x%02x value is 255 (FF); treating as unset (0)", addr)
+			return 0, nil
+		}
+		return regValue, nil
 	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	return 0, fmt.Errorf("registry row %s not found in response", prefix)
+}
 
-	hexstr := string(response[pos : pos+2])
-	reg_value, err := strconv.ParseInt(hexstr, 16, 64)
-	log.Debugf("Converted %v to int value: %d", hexstr, reg_value)
+// fetchRegistryDump requests an mXX dump for the given register address.
+// Node aligns the start to a 16-byte boundary (m05 → dump from 0x00) and prints ~80 bytes.
+func fetchRegistryDump(baudRate int, reg int) ([]byte, error) {
+	regCmd := fmt.Sprintf("m%02x", reg&0xff)
 
+	cmd := append([]byte("AT+XCMD="+regCmd), calcCRC16([]byte(regCmd))...)
+	log.Infof("fetch registry dump for 0x%02x via command %v", reg&0xff, cmd)
+
+	response, err := sendATCommand(string(cmd), baudRate)
 	if err != nil {
-		log.Errorf("parseInt error: %v", err)
-		reg_value = 0
-	} else if reg_value == 255 {
-		reg_value = 0
-		log.Debugf("Reg value is 255 (FF) re-setting int value: %d", reg_value)
+		return response, err
 	}
-	log.Infof("Reg value = %d", reg_value)
+	if len(response) == 0 {
+		return response, fmt.Errorf("empty response to %s", regCmd)
+	}
+	return response, nil
+}
 
-	return reg_value
+func getRegisteryData(baudRate int, reg int) (int64, bool) {
+	response, err := fetchRegistryDump(baudRate, reg)
+	if err != nil {
+		log.Warnf("registry read failed for 0x%02x: %v", reg, err)
+		return 0, false
+	}
+
+	regValue, err := parseRegistryByte(response, reg)
+	if err != nil {
+		log.Warnf("registry parse failed for 0x%02x: %v (response %q)", reg, err, string(response))
+		return 0, false
+	}
+	log.Infof("Reg 0x%02x value = %d", reg, regValue)
+	return regValue, true
 }
 
 /*
 
    Prediction event lockout mins
-   Time in minutes to have an prediction event lockout; default 30mins.
+   Time in minutes to have an prediction event lockout; default 1min.
    Read the 05 node registery to get the value
 
    2min = 'w0502’
@@ -324,40 +366,52 @@ func getRegisteryData(baudRate int, reg int) int64 {
 
 */
 
-func getPredictionEventLockout(baudRate int) int64 {
-
-	lockout_minutes := getRegisteryData(baudRate, predictionLockoutNodeRegister)
-
-	if lockout_minutes == 0 {
-		lockout_minutes = predictionLockoutMinutesDefault
+func getPredictionEventLockout(baudRate int, current int64) int64 {
+	lockoutMinutes, ok := getRegisteryData(baudRate, predictionLockoutNodeRegister)
+	if !ok {
+		log.Warnf("Prediction lockout read failed - retaining %d", current)
+		return current
+	}
+	if lockoutMinutes == 0 {
+		lockoutMinutes = predictionLockoutMinutesDefault
 		log.Infof("Prediction lockout time not set - using default (%d)", predictionLockoutMinutesDefault)
 	}
 
-	log.Infof("Prediction lockout time = %d (mins)", lockout_minutes)
-	return lockout_minutes
+	log.Infof("Prediction lockout time = %d (mins)", lockoutMinutes)
+	return lockoutMinutes
 }
 
 /*
-Battery event lockout mins
-Time in minutes to have an battery event lockout; default 180mins (3 hours).
-Read the 12 (hrs) + 13 (mins) node registery to get the value
+Battery / instrument reading interval.
+Default 180mins (3 hours). Read 0x12 (hrs) + 0x13 (mins) = HOURS/MINS_PER_INST_READING.
+Battery voltage is reported as an instrument reading, so this interval gates how often we send it.
 
 3hours = 'w1203’
 30min = 'w131e’
 */
-func getBatteryEventLockout(baudRate int) int64 {
-
-	hours := getRegisteryData(baudRate, batteryLockoutHoursNodeRegister)
-	mins := getRegisteryData(baudRate, batteryLockoutMinutesNodeRegister)
-
-	battery_lockout_minutes := hours*60 + mins
-	if battery_lockout_minutes <= 0 {
-		log.Infof("Battery lockout time not set - using default (%d)", batteryLockoutMinutesDefault)
-		battery_lockout_minutes = batteryLockoutMinutesDefault
+func getBatteryEventLockout(baudRate int, current int64) int64 {
+	// One dump covering both 0x12 and 0x13 (same 16-byte row after node align).
+	response, err := fetchRegistryDump(baudRate, batteryLockoutHoursNodeRegister)
+	if err != nil {
+		log.Warnf("Battery lockout registry read failed - retaining %d: %v", current, err)
+		return current
 	}
 
-	log.Infof("Battery lockout time = %d (mins)", battery_lockout_minutes)
-	return battery_lockout_minutes
+	hours, errH := parseRegistryByte(response, batteryLockoutHoursNodeRegister)
+	mins, errM := parseRegistryByte(response, batteryLockoutMinutesNodeRegister)
+	if errH != nil || errM != nil {
+		log.Warnf("Battery lockout parse failed - retaining %d (hours=%v mins=%v)", current, errH, errM)
+		return current
+	}
+
+	batteryLockoutMinutes := hours*60 + mins
+	if batteryLockoutMinutes <= 0 {
+		log.Infof("Battery lockout time not set - using default (%d)", batteryLockoutMinutesDefault)
+		batteryLockoutMinutes = batteryLockoutMinutesDefault
+	}
+
+	log.Infof("Battery lockout time = %d (mins)", batteryLockoutMinutes)
+	return batteryLockoutMinutes
 }
 
 func feedCRC16(crc uint16, dat byte) uint16 {

--- a/internal/tc2-hat-comms/at-esl_registry_test.go
+++ b/internal/tc2-hat-comms/at-esl_registry_test.go
@@ -1,0 +1,115 @@
+package comms
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseRegistryByte(t *testing.T) {
+	golden := strings.Join([]string{
+		"m00",
+		"",
+		"00: ff ff ff ff ff 1e aa bb cc dd ee ff 01 02 03 04",
+		"10: 00 00 03 1e ff ff ff ff ff ff ff ff ff ff ff ff",
+		"20: ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff",
+		"",
+		"O^K",
+	}, "\r\n")
+
+	mixed := string([]byte{0xa5, 0xfc}) + "\r\nO^K\r\n" + golden
+
+	tests := []struct {
+		name    string
+		resp    string
+		reg     int
+		want    int64
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			resp:    "",
+			reg:     0x05,
+			wantErr: true,
+		},
+		{
+			name:    "short garbage",
+			resp:    "\r",
+			reg:     0x05,
+			wantErr: true,
+		},
+		{
+			name:    "no dump lines",
+			resp:    "\r\nO^K\r\n",
+			reg:     0x05,
+			wantErr: true,
+		},
+		{
+			name: "prediction lockout reg 0x05",
+			resp: golden,
+			reg:  0x05,
+			want: 0x1e, // 30 mins
+		},
+		{
+			name: "battery hours reg 0x12",
+			resp: golden,
+			reg:  0x12,
+			want: 0x03,
+		},
+		{
+			name: "battery mins reg 0x13",
+			resp: golden,
+			reg:  0x13,
+			want: 0x1e,
+		},
+		{
+			name: "ff treated as unset zero",
+			resp: golden,
+			reg:  0x00,
+			want: 0,
+		},
+		{
+			name: "mixed prefix noise still parses",
+			resp: mixed,
+			reg:  0x05,
+			want: 0x1e,
+		},
+		{
+			name: "uppercase hex line",
+			resp: "00: FF FF FF FF FF 0A 00 00 00 00 00 00 00 00 00 00\r\n",
+			reg:  0x05,
+			want: 0x0a,
+		},
+		{
+			name:    "column past end of short line",
+			resp:    "00: ff ff\r\n",
+			reg:     0x05,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRegistryByte([]byte(tt.resp), tt.reg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got value %d", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %d want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalcCRC16Stable(t *testing.T) {
+	// Ensure AT+XCMD payload CRC helper still returns two bytes.
+	crc := calcCRC16([]byte("m00"))
+	if len(crc) != 2 {
+		t.Fatalf("expected 2 CRC bytes, got %d", len(crc))
+	}
+}

--- a/serialhelper/serialhelper.go
+++ b/serialhelper/serialhelper.go
@@ -209,6 +209,140 @@ func SerialSendReceive(retries int, mul0, mul1 gpio.Level, wait time.Duration, d
 	return response, nil
 }
 
+const (
+	defaultATReceiveTimeout = 3 * time.Second
+	defaultATDrainTimeout   = 200 * time.Millisecond
+	maxATResponseBytes      = 4096
+)
+
+// SerialSendReceiveUntil drains pending RX, writes data, then reads until the
+// response contains one of endMarkers (e.g. "O^K", "E^RROR"), the overall
+// timeout elapses after the write, or maxATResponseBytes is reached.
+// Unlike SerialSendReceive it keeps multi-line payloads (needed for AT+XCMD=m00).
+// Empty endMarkers means read until timeout/idle only.
+func SerialSendReceiveUntil(retries int, mul0, mul1 gpio.Level, wait time.Duration, data []byte, baud int, timeout time.Duration, endMarkers ...[]byte) ([]byte, error) {
+	if timeout <= 0 {
+		timeout = defaultATReceiveTimeout
+	}
+
+	serialFile, err := GetSerial(retries, mul0, mul1, wait)
+	if err != nil {
+		return nil, err
+	}
+	defer ReleaseSerial(serialFile)
+
+	// Short ReadTimeout so drain/idle detection does not block for seconds per read.
+	c := &serial.Config{Name: "/dev/serial0", Baud: baud, ReadTimeout: 100 * time.Millisecond}
+	serialPort, err := serial.OpenPort(c)
+	if err != nil {
+		return nil, err
+	}
+	defer serialPort.Close()
+
+	drained := drainSerial(serialPort, defaultATDrainTimeout)
+	if drained > 0 {
+		log.Debugf("Drained %d pending serial bytes before write", drained)
+	}
+
+	start := time.Now()
+	if len(data) == 0 || (data[len(data)-1] != '\n' && data[len(data)-1] != '\r') {
+		data = append(data, '\n')
+	}
+	n, err := serialPort.Write(data)
+	if err != nil {
+		return nil, err
+	}
+	if n != len(data) {
+		return nil, fmt.Errorf("wrote %d bytes, expected %d", n, len(data))
+	}
+
+	deadline := time.Now().Add(timeout)
+	var response []byte
+	var responseTime time.Time
+	firstBits := true
+	buf := make([]byte, 64)
+	idleRounds := 0
+	const idleRoundsToStop = 3 // ~300ms quiet after some data, or after markers missed
+
+	for time.Now().Before(deadline) {
+		n, err = serialPort.Read(buf)
+		if err != nil {
+			return response, err
+		}
+		if n == 0 {
+			if len(response) > 0 {
+				idleRounds++
+				if idleRounds >= idleRoundsToStop && len(endMarkers) == 0 {
+					break
+				}
+				// If we already saw a marker, a short idle is enough to finish.
+				if idleRounds >= idleRoundsToStop && containsAny(response, endMarkers...) {
+					break
+				}
+			}
+			continue
+		}
+		idleRounds = 0
+		if firstBits {
+			responseTime = time.Now()
+			firstBits = false
+		}
+		response = append(response, buf[:n]...)
+		if len(response) > maxATResponseBytes {
+			return response, fmt.Errorf("serial response exceeded %d bytes", maxATResponseBytes)
+		}
+		if len(endMarkers) > 0 && containsAny(response, endMarkers...) {
+			// Brief extra read window to catch trailing CR/LF after the marker.
+			extraDeadline := time.Now().Add(150 * time.Millisecond)
+			for time.Now().Before(extraDeadline) {
+				n, err = serialPort.Read(buf)
+				if err != nil || n == 0 {
+					break
+				}
+				response = append(response, buf[:n]...)
+				if len(response) > maxATResponseBytes {
+					break
+				}
+			}
+			break
+		}
+	}
+
+	log.Infof("Sent message at %s", start.Format("15:04:05.999"))
+	if !firstBits {
+		log.Infof("Received message at %s", responseTime.Format("15:04:05.999"))
+	}
+	log.Debugf("Received %d bytes (until markers/timeout)", len(response))
+	return response, nil
+}
+
+func drainSerial(port *serial.Port, timeout time.Duration) int {
+	deadline := time.Now().Add(timeout)
+	buf := make([]byte, 256)
+	total := 0
+	for time.Now().Before(deadline) {
+		n, err := port.Read(buf)
+		if err != nil || n == 0 {
+			if n == 0 {
+				// One empty read is enough once the FIFO looks quiet.
+				return total
+			}
+			return total
+		}
+		total += n
+	}
+	return total
+}
+
+func containsAny(data []byte, markers ...[]byte) bool {
+	for _, m := range markers {
+		if len(m) > 0 && bytes.Contains(data, m) {
+			return true
+		}
+	}
+	return false
+}
+
 func SerialSend(retries int, mul0, mul1 gpio.Level, wait time.Duration, data []byte, baud int) error {
 	start := time.Now()
 


### PR DESCRIPTION
- feat: Add SerialSendReceiveUntil for multi-line AT UART responses
- fix: Harden AT ESL registry reads and avoid slice-bounds panic
- test: Add unit tests for AT ESL registry dump parsing
